### PR TITLE
Added a HTML login form

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ All apps require the username `admin` and the password `password1234`.
 * `http/`
   * [basic_auth](http/basic_auth) - A Ruby Sinatra app that uses HTTP
     Basic-Auth.
+  * [html_login_form](http/html_login_form) - A Ruby Sinatra app that uses a
+    HTML login form.
 
 ## Contributing
 

--- a/http/html_login_form/Dockerfile
+++ b/http/html_login_form/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:3.1
+
+WORKDIR /app
+COPY . /app
+RUN bundle install
+
+EXPOSE 8000
+
+CMD ["bundle", "exec", "rackup", "--host", "0.0.0.0", "--port", "8000"]

--- a/http/html_login_form/Gemfile
+++ b/http/html_login_form/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'
+gem 'puma'
+gem 'warden'

--- a/http/html_login_form/Makefile
+++ b/http/html_login_form/Makefile
@@ -1,0 +1,12 @@
+all: run
+
+build: Dockerfile
+	docker build -t bruteforceable-http-html-login-form .
+
+run: build
+	docker run --rm -it -p 8080:80 bruteforceable-http-html-login-form
+
+clean:
+	docker image rm bruteforceable-http-html-login-form
+
+.PHONY: all build run clean

--- a/http/html_login_form/README.md
+++ b/http/html_login_form/README.md
@@ -1,0 +1,17 @@
+# Bruteforceable / HTTP / HTML-Login-Form
+
+## Build
+
+```shell
+make build
+```
+
+## Run
+
+```shell
+make run
+```
+
+## Login
+
+<http://localhost:8000/>

--- a/http/html_login_form/app.rb
+++ b/http/html_login_form/app.rb
@@ -1,0 +1,71 @@
+require 'sinatra/base'
+require 'warden'
+
+module Users
+  module_function
+
+  STORAGE = [
+    {username: "admin", password: "password1234"}
+  ]
+  
+  def load(username)
+    STORAGE.find { |user| user[:username] == username }
+  end
+
+  def verify_password(username, password)
+    user = load(username)
+    return user if user && user[:password] == password
+  end
+end
+
+Warden::Strategies.add(:password) do
+  def valid?
+    params["username"] || params["password"]
+  end
+
+  def authenticate!
+    if (user = Users.verify_password(params["username"], params["password"]))
+      success! user
+    else
+      fail! "Unauthorized"
+    end
+  end
+end
+
+class App < Sinatra::Base
+  enable :sessions
+
+  use Warden::Manager do |config|
+    config.serialize_into_session { |user| user[:username] }
+    config.serialize_from_session { |username| Users.load(username) }
+    config.scope_defaults :default, strategies: [:password], action: "auth/unauthenticated"
+    config.failure_app = self
+  end
+
+  get '/' do
+    env['warden'].authenticate!
+    erb :index
+  end
+
+  get '/auth/login' do
+    erb :login
+  end
+
+  post '/auth/login' do
+    env['warden'].authenticate!
+    redirect '/'
+  end
+
+  unathentication = -> { redirect '/auth/login' }
+  get  '/auth/unauthenticated', &unathentication
+  post '/auth/unauthenticated', &unathentication
+
+  get '/auth/logout' do
+    env['warden'].logout
+    redirect '/'
+  end
+end
+
+if $0 == __FILE__
+  App.run
+end

--- a/http/html_login_form/config.ru
+++ b/http/html_login_form/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run App

--- a/http/html_login_form/docker-compose.yml
+++ b/http/html_login_form/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  web:
+    image: bruteforceable-http-basic-auth
+    hostname: http-basic-auth.bruteforceable
+    build:
+      context: .
+    ports:
+      - "8000:8000"

--- a/http/html_login_form/views/index.erb
+++ b/http/html_login_form/views/index.erb
@@ -1,0 +1,1 @@
+<p>Top Secret</p>

--- a/http/html_login_form/views/layout.erb
+++ b/http/html_login_form/views/layout.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>bruteforceable</title>
+</head>
+<body>
+    <nav>
+        <ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="/auth/login">Login</a></li>
+            <li><a href="/auth/logout">Logout</a></li>
+        </ul>
+    </nav>
+    <article>
+        <%= yield %>
+    </article>
+</body>
+</html>

--- a/http/html_login_form/views/login.erb
+++ b/http/html_login_form/views/login.erb
@@ -1,0 +1,7 @@
+<form method="post">
+    <label for="username">Username</label>
+    <input type="text" name="username" id="username" />
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password" />
+    <input type="submit" value="Login" />
+</form>


### PR DESCRIPTION
Recycles the existing Sinatra app for basic_auth, but uses `warden` for login/session handling, mimicking common user storage patterns.

None of the username/password lookups and compare methods are cryptographically safe - so they are a good vector for timing attacks :)